### PR TITLE
CI TEST: testing build / link-check steps in CI workflow

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,4 +7,4 @@ linkTitle: 'Welcome'
 type: 'docs'
 ---
 
-Here is where I'll go into what this site is, the work that these docs represent, and how I built this site (docs-as-code).  Test.
+Here is where I'll go into what this site is, the work that these docs represent, and how I built this site (docs-as-code).


### PR DESCRIPTION
- Test if the refactored CI tests work
- CI build no longer builds to `site-root/samples-site`; this was done to replicate the URL structure of the provided GitHub Pages domain
- Remove word from placeholder text on home page.